### PR TITLE
Changed 'app.jsx' to 'App.jsx'

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
 module.exports = {
-  entry: path.join(__dirname, '/client/app.jsx'),
+  entry: path.join(__dirname, '/client/App.jsx'),
   output: {
     path: path.resolve(__dirname, "dist"),
     filename: 'bundle.js'


### PR DESCRIPTION
### `.jsx` name didn't match webpack entry-point
It was causing some errors in webpack.
Fixed it and moved on.

Feel free to incorporate this commit or leave it off.